### PR TITLE
Add JSON::MaybeXS to cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -10,3 +10,4 @@ requires 'Mojo::JSON';
 requires 'Compress::Zlib';
 requires 'Encode::Guess';
 requires 'Config::Tiny';
+requires 'JSON::MaybeXS';


### PR DESCRIPTION
While trying to compile the source code on Linux, perl raised an error, stating that this dependency was missing. After adding it, it compiled just fine. I don't know if this is an isolated case on my end, but I figured it would be interesting to propose this change anyway :D 